### PR TITLE
Support replacing primitive types in object

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var optimize = function(ops) {
 	/*
 	Optimization loop where we attempt to find operations that needlessly inserts and deletes identical objects right
 	after each other, and then consolidate them.
-	 */ 
+	 */
 	for (var i=0, l=ops.length-1; i < l; ++i) {
 		var a = ops[i], b = ops[i+1];
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var optimize = function(ops) {
 	/*
 	Optimization loop where we attempt to find operations that needlessly inserts and deletes identical objects right
 	after each other, and then consolidate them.
-	 */
+	 */ 
 	for (var i=0, l=ops.length-1; i < l; ++i) {
 		var a = ops[i], b = ops[i+1];
 

--- a/index.js
+++ b/index.js
@@ -66,9 +66,10 @@ var diff = function(input, output, path=[]) {
 		return [op];
 	}
 
-	// If either of input/output is a string, there is no need to perform deep recursive calls to
+	var primitiveTypes = ["string", "number", "boolean"];
+	// If either of input/output is a primitive type, there is no need to perform deep recursive calls to
 	// figure out what to do. We can just replace the objects.
-	if (typeof output === "string" || typeof input === "string") {
+	if (primitiveTypes.includes(typeof output) || primitiveTypes.includes(typeof input)) {
 		var op = { p: path };
 		op[isObject ? "od" : "ld"] = input;
 		op[isObject ? "oi" : "li"] = output;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,14 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -26,7 +28,8 @@
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
     },
     "chai": {
       "version": "4.1.2",
@@ -54,17 +57,20 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -85,17 +91,20 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -106,6 +115,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -118,22 +128,26 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
     },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
     },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -142,12 +156,14 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -155,12 +171,14 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -169,6 +187,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
       "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
         "commander": "2.11.0",
@@ -185,12 +204,14 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -203,7 +224,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "pathval": {
       "version": "1.1.0",
@@ -214,6 +236,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
       "requires": {
         "has-flag": "2.0.0"
       }
@@ -226,7 +249,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,232 @@
+{
+  "name": "json0-ot-diff",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "requires": {
+        "assertion-error": "1.0.2",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.5"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+    },
+    "clone": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "requires": {
+        "type-detect": "4.0.5"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "ot-json0": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ot-json0/-/ot-json0-1.0.1.tgz",
+      "integrity": "sha1-Pt/ntzvR8ZLAc30zIFDiNRW+NUo="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,10 +27,12 @@
   },
   "homepage": "https://github.com/kbadk/json0-ot-diff#readme",
   "dependencies": {
-    "chai": "^4.1.2",
     "clone": "^1.0.2",
     "deep-equal": "^1.0.1",
-    "mocha": "^4.0.1",
     "ot-json0": "^1.0.1"
+  },
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "mocha": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Finds differences between two JSON object and generates operational transformation (OT) operations for transforming the first object into the second.",
   "main": "index.js",
   "scripts": {
-    "test": "node tests.js"
+    "test": "node tests.js",
+    "mocha": "mocha",
+    "mocha-watch": "mocha --watch"
   },
   "repository": {
     "type": "git",
@@ -25,8 +27,10 @@
   },
   "homepage": "https://github.com/kbadk/json0-ot-diff#readme",
   "dependencies": {
+    "chai": "^4.1.2",
     "clone": "^1.0.2",
     "deep-equal": "^1.0.1",
+    "mocha": "^4.0.1",
     "ot-json0": "^1.0.1"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,220 @@
+"use strict";
+
+// Mocha assertions
+let assert = require("assert");
+// Library we're testing
+let jsondiff = require("../index.js");
+// json0 transform to work out if the right transform is being created
+let json0 = require("ot-json0/lib/json0");
+// Assertion expectations
+let expect = require("chai").expect;
+
+describe("Jsondiff", function() {
+  describe("Operations", function() {
+    describe("List Insert (li)", function() {
+      let tests = [
+        {
+          name: "Add one string to empty array",
+          start: [],
+          end: ["one"],
+          expectedCommand: [
+            {
+              p: [0],
+              li: "one"
+            }
+          ]
+        },
+        {
+          name: "Add one number to empty array",
+          start: [],
+          end: [1],
+          expectedCommand: [
+            {
+              p: [0],
+              li: 1
+            }
+          ]
+        },
+        {
+          name: "Add one boolean to empty array",
+          start: [],
+          end: [false],
+          expectedCommand: [
+            {
+              p: [0],
+              li: false
+            }
+          ]
+        },
+        {
+          name: "Add one string to end of non-empty array",
+          start: ["one"],
+          end: ["one", "two"],
+          expectedCommand: [
+            {
+              p: [1],
+              li: "two"
+            }
+          ]
+        },
+        {
+          name: "Add one number to end of non-empty array",
+          start: [1],
+          end: [1, 2],
+          expectedCommand: [
+            {
+              p: [1],
+              li: 2
+            }
+          ]
+        },
+        {
+          name: "Add one boolean to end of non-empty array",
+          start: [false],
+          end: [false, true],
+          expectedCommand: [
+            {
+              p: [1],
+              li: true
+            }
+          ]
+        },
+        {
+          name: "Add one string to middle of array",
+          start: ["one", "two"],
+          end: ["one", "three", "two"],
+          // This should need to be like this, but it works so leave it for now
+          expectedCommand: [
+            {
+              p: [1],
+              ld: "two",
+              li: "three"
+            },
+            {
+              p: [2],
+              li: "two"
+            }
+          ]
+        },
+        {
+          name: "Add one number to middle of array",
+          start: [1, 2],
+          end: [1, 3, 2],
+          expectedCommand: [
+            {
+              p: [2],
+              li: 2
+            }
+          ]
+        },
+        {
+          name: "Add one boolean to middle of array",
+          start: [false, false],
+          end: [false, true, false],
+          expectedCommand: [
+            {
+              p: [2],
+              li: false
+            }
+          ]
+        }
+      ];
+      tests.forEach(test => {
+        it(test.name, function() {
+          let output = jsondiff(test.start, test.end);
+          expect(output).to.deep.have.same.members(test.expectedCommand);
+        });
+      });
+    });
+    describe("Object Insert (oi)", function() {
+      let tests = [
+        {
+          name: "Add one string value to empty object",
+          start: {},
+          end: { one: "two" },
+          expectedCommand: [
+            {
+              p: ["one"],
+              oi: "two"
+            }
+          ]
+        },
+        {
+          name: "Add one number value to empty object",
+          start: {},
+          end: { one: 1 },
+          expectedCommand: [
+            {
+              p: ["one"],
+              oi: 1
+            }
+          ]
+        },
+        {
+          name: "Add one boolean value to empty object",
+          start: {},
+          end: { one: true },
+          expectedCommand: [
+            {
+              p: ["one"],
+              oi: true
+            }
+          ]
+        }
+      ];
+      tests.forEach(test => {
+        it(test.name, function() {
+          let output = jsondiff(test.start, test.end);
+          expect(output).to.deep.equal(test.expectedCommand);
+        });
+      });
+    });
+    describe("Object Replace (oi + od)", function() {
+      let tests = [
+        {
+          name: "Replaces one string value to empty object",
+          start: { one: "one" },
+          end: { one: "two" },
+          expectedCommand: [
+            {
+              p: ["one"],
+              oi: "two",
+              od: "one"
+            }
+          ]
+        },
+        {
+          name: "Replaces one number value to empty object",
+          start: { one: 1 },
+          end: { one: 2 },
+          expectedCommand: [
+            {
+              p: ["one"],
+              oi: 2,
+              od: 1
+            }
+          ]
+        },
+        {
+          name: "Replaces one boolean value to empty object",
+          start: { one: true },
+          end: { one: false },
+          expectedCommand: [
+            {
+              p: ["one"],
+              oi: true,
+              od: false
+            }
+          ]
+        }
+      ];
+      tests.forEach(test => {
+        it(test.name, function() {
+          let output = jsondiff(test.start, test.end);
+          console.log()
+          expect(output).to.deep.equal(test.expectedCommand);
+        });
+      });
+    });
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -78,12 +78,21 @@ describe("Jsondiff", function() {
               li: true
             }
           ]
-        },
+        }
+      ];
+      tests.forEach(test => {
+        it(test.name, function() {
+          let output = jsondiff(test.start, test.end);
+          expect(output).to.deep.have.same.members(test.expectedCommand);
+        });
+      });
+    });
+    describe("List Replace (oi + od)", function() {
+      let tests = [
         {
           name: "Add one string to middle of array",
           start: ["one", "two"],
           end: ["one", "three", "two"],
-          // This should need to be like this, but it works so leave it for now
           expectedCommand: [
             {
               p: [1],
@@ -102,6 +111,11 @@ describe("Jsondiff", function() {
           end: [1, 3, 2],
           expectedCommand: [
             {
+              p: [1],
+              ld: 2,
+              li: 3
+            },
+            {
               p: [2],
               li: 2
             }
@@ -112,6 +126,11 @@ describe("Jsondiff", function() {
           start: [false, false],
           end: [false, true, false],
           expectedCommand: [
+            {
+              p: [1],
+              ld: false,
+              li: true
+            },
             {
               p: [2],
               li: false
@@ -202,8 +221,8 @@ describe("Jsondiff", function() {
           expectedCommand: [
             {
               p: ["one"],
-              oi: true,
-              od: false
+              oi: false,
+              od: true
             }
           ]
         }
@@ -211,7 +230,6 @@ describe("Jsondiff", function() {
       tests.forEach(test => {
         it(test.name, function() {
           let output = jsondiff(test.start, test.end);
-          console.log()
           expect(output).to.deep.equal(test.expectedCommand);
         });
       });


### PR DESCRIPTION
First off, thank you for making this library!  It's been a great help for a project we have.

We found there was an issue where trying to replace object properties would fail if the type was a number.

The fix is a simple one, we create an array of primitive types that can be simply swapped out and check if either the input or output is of that type.

This simply extends the previous check of being just a string.

I also went ahead and added a testing framework.  If you want to see it in action:
Get the packages: npm i
Run tests: npm run mocha or npm run mocha-watch
