### PR TITLE
Add support for String Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Finds differences between two JSON object and generates operational transformation (OT) operations for transforming the first object into the second according to the [JSON0 OT Type](https://github.com/ottypes/json0).
 
-The current implementation only supports list/object insertion/deletion (i.e. `li`, `ld`, `oi`, `od`).
+The current implementation supports list/object insertion/deletion (i.e. `li`, `ld`, `oi`, `od`) out of the box.
 
 	var jsondiff = require("./json0-ot-diff");
 
@@ -15,6 +15,21 @@ The current implementation only supports list/object insertion/deletion (i.e. `l
 	> [
 	>	{ p: [ 1 ], ld: 'bar', li: 'quux' },
 	>	{ p: [ 4 ], ld: 3 }
+	>]
+
+String insertion/deletion (i.e. `si`, `sd`) operations are generated for string mutations if you provide a reference to [diff-match-patch](https://github.com/google/diff-match-patch).
+
+	var diffMatchPatch = require("diff-match-patch");
+	var diff = jsondiff(
+		["foo", "The only change here is at the end.", 1, 2, 3],
+		["foo", "The only change here is at the very end.", 1, 2],
+		diffMatchPatch
+	);
+	console.log(diff);
+
+	> [
+	> { p: [ 1, 31 ], si: 'very ' },
+	> { p: [ 4 ], ld: 3 }
 	>]
 
 This was developed for [JsonML](http://www.jsonml.org/) with [Webstrates](https://github.com/cklokmose/Webstrates) in mind, but could be applicable in other situations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "json0-ot-diff",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "assertion-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -35,6 +36,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
       "requires": {
         "assertion-error": "1.0.2",
         "check-error": "1.0.2",
@@ -47,7 +49,8 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "clone": {
       "version": "1.0.3",
@@ -79,6 +82,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
       "requires": {
         "type-detect": "4.0.5"
       }
@@ -92,6 +96,12 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "diff-match-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
+      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg=",
       "dev": true
     },
     "escape-string-regexp": {
@@ -109,7 +119,8 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.2",
@@ -230,7 +241,8 @@
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "supports-color": {
       "version": "4.4.0",
@@ -244,7 +256,8 @@
     "type-detect": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ=="
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
+    "diff-match-patch": "^1.0.0",
     "mocha": "^4.0.1"
   }
 }


### PR DESCRIPTION
Closes #4

I added only a few test cases, inspired from the [diff-match-patch tests](https://github.com/google/diff-match-patch/blob/master/javascript/tests/diff_match_patch_test.js#L79) (from which we could draw more test cases if desired).

The `patchesToOps` function was verbatim copied from the [Webstrates implementation](https://github.com/Webstrates/Webstrates/blob/9ddb44164110f21ae8606a1750f345d11d59d271/client/webstrates/coreOpCreator.js#L38-L62) by @kbadk , with the addition only of the extra arguments for passing in diffMatchPatch.

It's exciting to see it seems to work well!