### PR TITLE
Add Top level string test

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -240,6 +240,15 @@ describe("Jsondiff", function() {
       // These test cases come from diff-match-patch tests.
       let tests = [
         {
+          name: "Top level string",
+          start: "one",
+          end: "two",
+          expectedCommand: [
+            { sd: "one", p: [] },
+            { si: "two", p: [] }
+          ]
+        },
+        {
           name: "Strings with a common prefix, null case",
           start: { one: "one" },
           end: { one: "two" },


### PR DESCRIPTION
Greetings,

I happened to be checking if the library does the right thing if the top level data is itself a string. It does! I figured I'd add a new test that covers this case.