### PR TITLE
Add iterative tests

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -270,6 +270,15 @@ describe("Jsondiff", function() {
           ]
         },
         {
+          name: "Strings suffix/prefix overlap, overlap case",
+          start: { one: "123456xxx" },
+          end: { one: "xxxabcd" },
+          expectedCommand: [
+            { "p": [ "one", 0 ], "sd": "123456xxx" },
+            { "p": [ "one", 0 ], "si": "xxxabcd" }
+          ]
+        },
+        {
           name: "Example from README",
           start: ["foo", "The only change here is at the end.", 1, 2, 3],
           end: ["foo", "The only change here is at the very end.", 1, 2],

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -89,12 +89,7 @@ describe("Jsondiff", function() {
           ]
         }
       ];
-      tests.forEach(test => {
-        it(test.name, function() {
-          let output = jsondiff(test.start, test.end);
-          expect(output).to.deep.have.same.members(test.expectedCommand);
-        });
-      });
+      runTests(tests);
     });
     describe("List Replace (oi + od)", function() {
       let tests = [
@@ -147,12 +142,7 @@ describe("Jsondiff", function() {
           ]
         }
       ];
-      tests.forEach(test => {
-        it(test.name, function() {
-          let output = jsondiff(test.start, test.end);
-          expect(output).to.deep.have.same.members(test.expectedCommand);
-        });
-      });
+      runTests(tests);
     });
     describe("Object Insert (oi)", function() {
       let tests = [
@@ -190,12 +180,7 @@ describe("Jsondiff", function() {
           ]
         }
       ];
-      tests.forEach(test => {
-        it(test.name, function() {
-          let output = jsondiff(test.start, test.end);
-          expect(output).to.deep.equal(test.expectedCommand);
-        });
-      });
+      runTests(tests);
     });
     describe("Object Replace (oi + od)", function() {
       let tests = [
@@ -236,12 +221,7 @@ describe("Jsondiff", function() {
           ]
         }
       ];
-      tests.forEach(test => {
-        it(test.name, function() {
-          let output = jsondiff(test.start, test.end);
-          expect(output).to.deep.equal(test.expectedCommand);
-        });
-      });
+      runTests(tests);
     });
     describe("String Mutation (si + sd)", function() {
       // These test cases come from diff-match-patch tests.
@@ -308,39 +288,43 @@ describe("Jsondiff", function() {
           ]
         }
       ];
-      tests.forEach(test => {
-        it(test.name, function() {
-
-          //////////////////
-          // Verify JSON0 //
-          //////////////////
-          let json0Op = jsondiff(test.start, test.end, diffMatchPatch);
-          expect(json0Op).to.deep.equal(test.expectedCommand);
-
-          // Test actual application of the expected ops.
-          // Clone the input, because json0 mutates the input to `apply`.
-          let json0Start = clone(test.start);
-          let json0End = json0.type.apply(json0Start, json0Op);
-          expect(json0End).to.deep.equal(test.end);
-
-
-          //////////////////
-          // Verify JSON1 //
-          //////////////////
-          let json1Op = jsondiff(
-            test.start,
-            test.end,
-            diffMatchPatch,
-            json1,
-            textUnicode
-          );
-
-          // Test actual application of the expected ops.
-          // No need to clone the input, json1 does _not_ mutate the input to `apply`.
-          let json1End = json1.type.apply(test.start, json1Op);
-          expect(json1End).to.deep.equal(test.end);
-        });
-      });
+      runTests(tests);
     });
   });
 });
+
+function runTests(tests) {
+  tests.forEach(test => {
+    it(test.name, function() {
+
+      //////////////////
+      // Verify JSON0 //
+      //////////////////
+      let json0Op = jsondiff(test.start, test.end, diffMatchPatch);
+      expect(json0Op).to.deep.equal(test.expectedCommand);
+
+      // Test actual application of the expected ops.
+      // Clone the input, because json0 mutates the input to `apply`.
+      let json0Start = clone(test.start);
+      let json0End = json0.type.apply(json0Start, json0Op);
+      expect(json0End).to.deep.equal(test.end);
+
+
+      //////////////////
+      // Verify JSON1 //
+      //////////////////
+      let json1Op = jsondiff(
+        test.start,
+        test.end,
+        diffMatchPatch,
+        json1,
+        textUnicode
+      );
+
+      // Test actual application of the expected ops.
+      // No need to clone the input, json1 does _not_ mutate the input to `apply`.
+      let json1End = json1.type.apply(test.start, json1Op);
+      expect(json1End).to.deep.equal(test.end);
+    });
+  });
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -98,15 +98,9 @@ describe("Jsondiff", function() {
           start: ["one", "two"],
           end: ["one", "three", "two"],
           expectedCommand: [
-            {
-              p: [1],
-              ld: "two",
-              li: "three"
-            },
-            {
-              p: [2],
-              li: "two"
-            }
+            { sd: 'wo', p: [ 1, 1 ] },
+            { si: 'hree', p: [ 1, 1 ] },
+            { p: [ 2 ], li: 'two' }
           ]
         },
         {
@@ -189,11 +183,8 @@ describe("Jsondiff", function() {
           start: { one: "one" },
           end: { one: "two" },
           expectedCommand: [
-            {
-              p: ["one"],
-              oi: "two",
-              od: "one"
-            }
+            { sd: 'one', p: [ 'one', 0 ] },
+            { si: 'two', p: [ 'one', 0 ] }
           ]
         },
         {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -309,6 +309,12 @@ function runTests(tests) {
       let json0End = json0.type.apply(json0Start, json0Op);
       expect(json0End).to.deep.equal(test.end);
 
+      // Test application of ops generated _without_ diffMatchPatch.
+      let json0SimpleOp = jsondiff(test.start, test.end);
+      let json0SimpleStart = clone(test.start);
+      let json0SimpleEnd = json0.type.apply(json0SimpleStart, json0SimpleOp);
+      expect(json0SimpleEnd).to.deep.equal(test.end);
+
 
       //////////////////
       // Verify JSON1 //

--- a/tests.js
+++ b/tests.js
@@ -10,6 +10,28 @@ let textUnicode = require("ot-text-unicode");
 var jsondiff = require("./index.js");
 
 var tests = [
+  //tests of equality
+  [
+	[
+		5,
+		5,
+	],
+	[
+		"foo",
+		"foo",
+	],
+	[
+		["foo"],
+		["foo"],
+	],
+	[
+		[],
+		[],
+	],
+	[
+		{},
+		{},
+	],
 	//tests of li/ld
 	[
 		[],

--- a/tests.js
+++ b/tests.js
@@ -11,7 +11,6 @@ var jsondiff = require("./index.js");
 
 var tests = [
   //tests of equality
-  [
 	[
 		5,
 		5,
@@ -87,6 +86,43 @@ var tests = [
 		[	{ foo: 'bar' } ],
 		[	{} ]
 	],
+	// string tests
+  // Inspired by https://github.com/google/diff-match-patch/blob/master/javascript/tests/diff_match_patch_test.js
+  ["abc", "xyz"],
+  ["1234abcdef", "1234xyz"],
+  ["1234", "1234xyz"],
+  ["abc", "xyz"],
+  ["abcdef1234", "xyz1234"],
+  ["1234", "xyz1234"],
+  ["", "abcd"],
+  ["abc", "abcd"],
+  ["123456", "abcd"],
+  ["123456xxx", "xxxabcd"],
+  ["fi", "\ufb01i"],
+  ["1234567890", "abcdef"],
+  ["12345", "23"],
+  ["1234567890", "a345678z"],
+  ["a345678z", "1234567890"],
+  ["abc56789z", "1234567890"],
+  ["a23456xyz", "1234567890"],
+  ["121231234123451234123121", "a1234123451234z"],
+  ["x-=-=-=-=-=-=-=-=-=-=-=-=", "xx-=-=-=-=-=-=-="],
+  ["-=-=-=-=-=-=-=-=-=-=-=-=y", "-=-=-=-=-=-=-=yy"],
+  ["qHilloHelloHew", "xHelloHeHulloy"],
+  ["abcdefghijk", "fgh"],
+  ["abcdefghijk", "efxhi"],
+  ["abcdefghijk", "cdefxyhijk"],
+  ["abcdefghijk", "bxy"],
+  ["123456789xx0", "3456789x0"],
+  ["abcdefghijk", "efxyhi"],
+  ["abcdefghijk", "bcdef"],
+  ["abcdexyzabcde", "abccde"],
+  ["abcdefghijklmnopqrstuvwxyz01234567890", "XabXcdXefXghXijXklXmnXopXqrXstXuvXwxXyzX01X23X45X67X89X0"],
+  ["abcdef1234567890123456789012345678901234567890123456789012345678901234567890uvwxyz", "abcdefuvwxyz"],
+  ["1234567890123456789012345678901234567890123456789012345678901234567890", "abc"],
+  ["XY", "XtestY"],
+  ["XXXXYYYY", "XXXXtestYYYY"],
+  ["The quick brown fox jumps over the lazy dog.", "Woof"],
 	// big tests
 	[
 		[],
@@ -162,6 +198,10 @@ tests.forEach(function([input, output]) {
 // Actual tests for json0
 tests.forEach(function([input, output]) {
 	var ops = jsondiff(input, output);
+
+  // Don't let json0 mutate the input,
+  // so we can use it in later tests.
+  input = clone(input);
 	ops.forEach(function(op) {
 		assert.doesNotThrow(function() {
 			input = json0.type.apply(input, [op]);
@@ -179,7 +219,7 @@ tests.forEach(function([input, output]) {
 		json1,
 		textUnicode
 	);
-	assert(equal(input, json1.type.apply(input, ops)));
+	assert(equal(json1.type.apply(input, ops), output));
 });
 
 console.log("No errors!");

--- a/tests.js
+++ b/tests.js
@@ -87,42 +87,42 @@ var tests = [
 		[	{} ]
 	],
 	// string tests
-  // Inspired by https://github.com/google/diff-match-patch/blob/master/javascript/tests/diff_match_patch_test.js
-  ["abc", "xyz"],
-  ["1234abcdef", "1234xyz"],
-  ["1234", "1234xyz"],
-  ["abc", "xyz"],
-  ["abcdef1234", "xyz1234"],
-  ["1234", "xyz1234"],
-  ["", "abcd"],
-  ["abc", "abcd"],
-  ["123456", "abcd"],
-  ["123456xxx", "xxxabcd"],
-  ["fi", "\ufb01i"],
-  ["1234567890", "abcdef"],
-  ["12345", "23"],
-  ["1234567890", "a345678z"],
-  ["a345678z", "1234567890"],
-  ["abc56789z", "1234567890"],
-  ["a23456xyz", "1234567890"],
-  ["121231234123451234123121", "a1234123451234z"],
-  ["x-=-=-=-=-=-=-=-=-=-=-=-=", "xx-=-=-=-=-=-=-="],
-  ["-=-=-=-=-=-=-=-=-=-=-=-=y", "-=-=-=-=-=-=-=yy"],
-  ["qHilloHelloHew", "xHelloHeHulloy"],
-  ["abcdefghijk", "fgh"],
-  ["abcdefghijk", "efxhi"],
-  ["abcdefghijk", "cdefxyhijk"],
-  ["abcdefghijk", "bxy"],
-  ["123456789xx0", "3456789x0"],
-  ["abcdefghijk", "efxyhi"],
-  ["abcdefghijk", "bcdef"],
-  ["abcdexyzabcde", "abccde"],
-  ["abcdefghijklmnopqrstuvwxyz01234567890", "XabXcdXefXghXijXklXmnXopXqrXstXuvXwxXyzX01X23X45X67X89X0"],
-  ["abcdef1234567890123456789012345678901234567890123456789012345678901234567890uvwxyz", "abcdefuvwxyz"],
-  ["1234567890123456789012345678901234567890123456789012345678901234567890", "abc"],
-  ["XY", "XtestY"],
-  ["XXXXYYYY", "XXXXtestYYYY"],
-  ["The quick brown fox jumps over the lazy dog.", "Woof"],
+	// Inspired by https://github.com/google/diff-match-patch/blob/master/javascript/tests/diff_match_patch_test.js
+	["abc", "xyz"],
+	["1234abcdef", "1234xyz"],
+	["1234", "1234xyz"],
+	["abc", "xyz"],
+	["abcdef1234", "xyz1234"],
+	["1234", "xyz1234"],
+	["", "abcd"],
+	["abc", "abcd"],
+	["123456", "abcd"],
+	["123456xxx", "xxxabcd"],
+	["fi", "\ufb01i"],
+	["1234567890", "abcdef"],
+	["12345", "23"],
+	["1234567890", "a345678z"],
+	["a345678z", "1234567890"],
+	["abc56789z", "1234567890"],
+	["a23456xyz", "1234567890"],
+	["121231234123451234123121", "a1234123451234z"],
+	["x-=-=-=-=-=-=-=-=-=-=-=-=", "xx-=-=-=-=-=-=-="],
+	["-=-=-=-=-=-=-=-=-=-=-=-=y", "-=-=-=-=-=-=-=yy"],
+	["qHilloHelloHew", "xHelloHeHulloy"],
+	["abcdefghijk", "fgh"],
+	["abcdefghijk", "efxhi"],
+	["abcdefghijk", "cdefxyhijk"],
+	["abcdefghijk", "bxy"],
+	["123456789xx0", "3456789x0"],
+	["abcdefghijk", "efxyhi"],
+	["abcdefghijk", "bcdef"],
+	["abcdexyzabcde", "abccde"],
+	["abcdefghijklmnopqrstuvwxyz01234567890", "XabXcdXefXghXijXklXmnXopXqrXstXuvXwxXyzX01X23X45X67X89X0"],
+	["abcdef1234567890123456789012345678901234567890123456789012345678901234567890uvwxyz", "abcdefuvwxyz"],
+	["1234567890123456789012345678901234567890123456789012345678901234567890", "abc"],
+	["XY", "XtestY"],
+	["XXXXYYYY", "XXXXtestYYYY"],
+	["The quick brown fox jumps over the lazy dog.", "Woof"],
 	// big tests
 	[
 		[],
@@ -199,9 +199,9 @@ tests.forEach(function([input, output]) {
 tests.forEach(function([input, output]) {
 	var ops = jsondiff(input, output);
 
-  // Don't let json0 mutate the input,
-  // so we can use it in later tests.
-  input = clone(input);
+	// Don't let json0 mutate the input,
+	// so we can use it in later tests.
+	input = clone(input);
 	ops.forEach(function(op) {
 		assert.doesNotThrow(function() {
 			input = json0.type.apply(input, [op]);

--- a/tests.js
+++ b/tests.js
@@ -10,7 +10,7 @@ let textUnicode = require("ot-text-unicode");
 var jsondiff = require("./index.js");
 
 var tests = [
-  //tests of equality
+	// Tests of equality
 	[
 		5,
 		5,
@@ -31,7 +31,7 @@ var tests = [
 		{},
 		{},
 	],
-	//tests of li/ld
+	// Tests of li/ld
 	[
 		[],
 		["foo"]
@@ -64,7 +64,7 @@ var tests = [
 		["foo", "bar", "quux"],
 		["bar", "quux"]
 	],
-	// tests for object/array
+	// Tests for object/array
 	[
 		{},
 		[]
@@ -73,7 +73,7 @@ var tests = [
 		[],
 		{}
 	],
-	// tests for oi/od
+	// Tests for oi/od
 	[
 		{},
 		{"foo":"bar"}
@@ -86,7 +86,7 @@ var tests = [
 		[	{ foo: 'bar' } ],
 		[	{} ]
 	],
-	// string tests
+	// String tests
 	// Inspired by https://github.com/google/diff-match-patch/blob/master/javascript/tests/diff_match_patch_test.js
 	["abc", "xyz"],
 	["1234abcdef", "1234xyz"],
@@ -123,7 +123,7 @@ var tests = [
 	["XY", "XtestY"],
 	["XXXXYYYY", "XXXXtestYYYY"],
 	["The quick brown fox jumps over the lazy dog.", "Woof"],
-	// big tests
+	// Big tests
 	[
 		[],
 		["the", {"quick":"brown", "fox":"jumped"}, "over", {"the": ["lazy", "dog"]}]
@@ -136,7 +136,7 @@ var tests = [
 		[["the", {"quick":"black", "fox":"jumped"}, "over", {"the": ["lazy", "dog"]}]],
 		["the", {"quick":"brown", "fox":"leapt"}, "over", {"the": ["stupid", "dog"]}]
 	],
-	// real-life jsonml tests
+	// Real-life jsonml tests
 	[
 		[ 'html', {}, [ 'body', {}, '\n\n', '\n\n',     [ 'p', {}, 'Quux!' ] ], '\n' ],
 		[ 'html', {}, [ 'body', {}, '\n\n', '\n\n\n\n', [ 'p', {}, 'Quux!' ] ], '\n' ]


### PR DESCRIPTION
Based on some downstream development work, I became suspicious that there might be some bug in the string support with JSON1. So I double checked all the tests here to make sure everything was covered. I noticed several issues with the tests and fixed them here in this PR.

 - The new modifications I did to the test runner earlier were only applied to the last set of tests. This PR makes it so all the tests are actually verified.
 - In `tests.js`, the input was being mutated by json0, so the json1 tests were actually all just getting the same object as input and as output. This PR fixes that.
 - I added some new tests for equivalent input and output, and also for strings. They all passed out of the box.

I'm happy to report that all of the tests do in fact pass, and no bug in the implementation was found.